### PR TITLE
Fix requests made without callback.

### DIFF
--- a/src/serf/client.py
+++ b/src/serf/client.py
@@ -287,7 +287,7 @@ class Client (threading.local, ) :
             except _exceptions.StopReceiveData :
                 break
 
-            if _response_callbacked :
+            if not _response_callbacked :
                 _responses.append(_response, )
 
             if not _response.has_more_responses :

--- a/src/serf/response.py
+++ b/src/serf/response.py
@@ -137,12 +137,11 @@ class ResponseQuery (ResponseWithBody, ) :
     has_more_responses = True
 
     def callback (self, ) :
-        super(ResponseQuery, self).callback()
 
         if self.body.get('Type') in ('done', ) :
             self.has_more_responses = False
 
-        return self
+        return super(ResponseQuery, self).callback()
 
     def _parse_body (self, body, ) :
         if body and body.get('Type') in ('ack', ) and not body.get('From', ) :

--- a/test/test_command_query.py
+++ b/test/test_command_query.py
@@ -81,7 +81,9 @@ def test_response_query () :
         assert response.is_success
         assert response.body is not None
         assert response.seq == 1
+        assert response.body == QueryFakeConnection.responses[len(_responses)]
 
+        _responses.append(response)
         return
 
 
@@ -94,17 +96,9 @@ def test_response_query () :
             Payload='this is payload of `response-me` query event',
         )
 
-    _responses_all = _client.query(**_body).add_callback(_callback, ).watch()
-
     _responses = list()
-    for i in _responses_all :
-        if i.request.command not in ('query', ) :
-            continue
 
-        _responses.append(i, )
-
-    for _n, i in enumerate(QueryFakeConnection.responses) :
-        assert _responses[_n].body == i
+    _client.query(**_body).add_callback(_callback, ).watch()
 
 
 class QueryFakeConnectionInvalidResponse (QueryFakeConnection, ) :

--- a/test/test_request.py
+++ b/test/test_request.py
@@ -129,7 +129,6 @@ def test_response_auth_failed () :
             Payload='payload',
         )
 
-    _responses = _client.event(**_body).add_callback(_callback, ).request()
-    assert len(_responses) == 2
+    _client.event(**_body).add_callback(_callback, ).request()
 
 


### PR DESCRIPTION
Requests made without a callback function would return an empty list.
For example, client.members().request() as mentioned in the docs.

Fixed this by negating the check for including a response in the
return list. And fixed a bug in the ResponseQuery.callback() return
value where it always returns itself (it should return None if there
are no callbacks).
