### PR TITLE
Change msgpack-python requirement to msgpack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import setup
 
 _requires = [
-        'msgpack-python',
+        'msgpack',
     ]
 
 if sys.version_info < (2, 7, 0, ) :


### PR DESCRIPTION
This package has been renamed to `msgpack` starting with their `0.5.0` version. The old package seems likely to be deprecated soon, but this change will keep the dependency being updated as intended.

https://pypi.python.org/pypi/msgpack
https://pypi.python.org/pypi/msgpack-python